### PR TITLE
Filter tweets

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -162,6 +162,30 @@ body {
 
 .countrylist .flag-icon { margin: 0px 5px; }
 
+.filterList {
+  position: absolute;
+  top: 300px;
+  left: 100px;
+  background: white;
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  border-bottom-color: gray;
+}
+
+.filterList li {
+  list-style: none;
+  cursor: pointer;
+}
+
+.filterList li:hover {
+  background: aliceblue;
+}
+
+.filterList .inactive {
+  text-decoration: line-through;
+}
+
 .img {
 	background-size: 100% 100%;
 	background-repeat: no-repeat;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -73,6 +73,7 @@ export function deleteFilter(filter) {
 export function setFilterActive(filter, active) {
   return {
     type: FILTER_ACTIVE_CHANGED,
+    filter,
     active
   };
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,6 +4,9 @@ export const TWEET_RECEIVED = 'TWEET_RECEIVED';
 export const TWEET_SELECTED = 'TWEET_SELECTED';
 export const TWEET_SAVED = 'TWEET_SAVED';
 export const SAVED_TWEETS_FETCH = 'SAVED_TWEETS_FETCH';
+export const FILTER_ADDED = 'FILTER_ADDED';
+export const FILTER_DELETED = 'FILTER_DELETED';
+export const FILTER_ACTIVE_CHANGED = 'FILTER_ACTIVE_CHANGED';
 
 export function newTweet(tweet) {
   return {
@@ -53,3 +56,23 @@ export function fetchSavedTweets() {
   };
 }
 
+export function addFilter(filter) {
+  return {
+    type: FILTER_ADDED,
+    filter
+  };
+}
+
+export function deleteFilter(filter) {
+  return {
+    type: FILTER_DELETED,
+    filter
+  };
+}
+
+export function setFilterActive(filter, active) {
+  return {
+    type: FILTER_ACTIVE_CHANGED,
+    active
+  };
+}

--- a/src/components/FilterList.jsx
+++ b/src/components/FilterList.jsx
@@ -1,0 +1,40 @@
+import React, { PropTypes } from 'react';
+
+function Filter({ name, isActive, onNameClick }) {
+  const className = isActive ? '' : 'inactive';
+  return (
+    <span
+      className={ className }
+      onClick={ onNameClick }
+    >
+      { name }
+    </span>
+  );
+}
+
+Filter.propTypes = {
+  name: PropTypes.string.isRequired,
+  isActive: PropTypes.bool,
+  onNameClick: PropTypes.func.isRequired
+};
+
+function FilterList({ filters, onFilterActiveChange }) {
+  return (
+    <ul className="filterList">
+      { filters.map(f =>
+        <li key={ f.id }>
+          <Filter
+            {...f}
+            onNameClick={ () => onFilterActiveChange(f, !f.isActive) }
+          />
+        </li>)}
+    </ul>
+  );
+}
+
+FilterList.propTypes = {
+  filters: PropTypes.array.isRequired,
+  onFilterActiveChange: PropTypes.func.isRequired
+};
+
+export default FilterList;

--- a/src/components/TweetMap.jsx
+++ b/src/components/TweetMap.jsx
@@ -1,14 +1,27 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { GoogleMap, Marker, GoogleMapLoader } from 'react-google-maps';
+import { findFilterMatch } from '../util/filters';
 
-export default function TweetMap({ tweets, showTweet, currentTweet }) {
+function TweetMap({
+  tweets,
+  showTweet,
+  currentTweet,
+  filters
+}) {
   const markers = tweets.map(t => {
     const callback = () => {
       showTweet(t.id);
     };
-    const icon = t === currentTweet ?
-      'http://maps.google.com/mapfiles/ms/icons/green-dot.png' :
-      'http://maps.google.com/mapfiles/ms/icons/red-dot.png';
+
+    const filterMatch = findFilterMatch(t, filters);
+    const color = filterMatch ? filterMatch.color : null;
+
+    let icon = 'http://maps.google.com/mapfiles/ms/icons/red-dot.png';
+    if (t === currentTweet) {
+      icon = 'http://maps.google.com/mapfiles/ms/icons/green-dot.png';
+    } else if (color) {
+      icon = `http://maps.google.com/mapfiles/ms/icons/${color}-dot.png`;
+    }
 
     return (
       <Marker
@@ -35,3 +48,12 @@ export default function TweetMap({ tweets, showTweet, currentTweet }) {
     </div>
   );
 }
+
+TweetMap.propTypes = {
+  tweets: PropTypes.array.isRequired,
+  showTweet: PropTypes.func.isRequired,
+  currentTweet: PropTypes.object,
+  filters: PropTypes.array
+};
+
+export default TweetMap;

--- a/src/containers/Map.jsx
+++ b/src/containers/Map.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { selectTweet } from '../actions';
 
 import TweetMap from '../components/TweetMap';
-import AppHeader from '../components/AppHeader';
 import CountryList from '../components/CountryList';
 import CurrentTweet from '../components/CurrentTweet';
 import InfluentialTweets from '../components/InfluentialTweets';
@@ -22,7 +21,12 @@ class Map extends React.Component {
   }
 
   render() {
-    const { currentTweet, tweets, tweetCount, countries } = this.props;
+    const {
+      currentTweet,
+      tweets,
+      countries,
+      filters
+    } = this.props;
     const tweet = currentTweet !== null ?
       <CurrentTweet tweet={ currentTweet } /> :
       null;
@@ -33,6 +37,7 @@ class Map extends React.Component {
           tweets={ tweets }
           currentTweet={ currentTweet }
           showTweet={ this.showTweet }
+          filters={ filters }
         />
         <InfluentialTweets tweets={ tweets } />
         <CountryList countries={ countries } />
@@ -47,14 +52,15 @@ Map.propTypes = {
   tweetCount: PropTypes.number,
   currentTweet: PropTypes.object,
   countries: PropTypes.object,
+  filters: PropTypes.array,
   dispatch: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
   tweets: state.tweets,
-  tweetCount: state.view.tweetCount,
   currentTweet: state.view.currentTweet,
-  countries: state.countries
+  countries: state.countries,
+  filters: state.filters
 });
 
 export default connect(mapStateToProps)(Map);

--- a/src/containers/Map.jsx
+++ b/src/containers/Map.jsx
@@ -1,12 +1,13 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { selectTweet } from '../actions';
+import { selectTweet, setFilterActive } from '../actions';
 
 import TweetMap from '../components/TweetMap';
 import CountryList from '../components/CountryList';
 import CurrentTweet from '../components/CurrentTweet';
 import InfluentialTweets from '../components/InfluentialTweets';
+import FilterList from '../components/FilterList';
 
 class Map extends React.Component {
   constructor(props) {
@@ -25,11 +26,14 @@ class Map extends React.Component {
       currentTweet,
       tweets,
       countries,
-      filters
+      filters,
+      dispatch
     } = this.props;
     const tweet = currentTweet !== null ?
       <CurrentTweet tweet={ currentTweet } /> :
       null;
+
+    const activeFilters = filters.filter(f => f.isActive);
 
     return (
       <div>
@@ -37,10 +41,14 @@ class Map extends React.Component {
           tweets={ tweets }
           currentTweet={ currentTweet }
           showTweet={ this.showTweet }
-          filters={ filters }
+          filters={ activeFilters }
         />
         <InfluentialTweets tweets={ tweets } />
         <CountryList countries={ countries } />
+        <FilterList
+          filters={ filters }
+          onFilterActiveChange={ (f, active) => dispatch(setFilterActive(f, active)) }
+        />
         { tweet }
       </div>
     );
@@ -52,7 +60,7 @@ Map.propTypes = {
   tweetCount: PropTypes.number,
   currentTweet: PropTypes.object,
   countries: PropTypes.object,
-  filters: PropTypes.array,
+  filters: PropTypes.array.isRequired,
   dispatch: PropTypes.func.isRequired
 };
 
@@ -60,7 +68,10 @@ const mapStateToProps = state => ({
   tweets: state.tweets,
   currentTweet: state.view.currentTweet,
   countries: state.countries,
-  filters: state.filters
+  filters: state.filters.map(f => ({
+    ...f,
+    isActive: state.view.activeFilterIdsMap[f.id]
+  }))
 });
 
 export default connect(mapStateToProps)(Map);

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -1,0 +1,20 @@
+import {
+  FILTER_ADDED,
+  FILTER_DELETED
+} from '../actions';
+
+const initialState = [];
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+  case FILTER_ADDED:
+    return [
+      ...state.all,
+      action.filter
+    ];
+  case FILTER_DELETED:
+    return state.filter(f => f.name !== action.filter.id);
+  default:
+    return state;
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,9 +3,11 @@ import { combineReducers } from 'redux';
 import tweets from './tweets';
 import countries from './countries';
 import view from './view';
+import filters from './filters';
 
 export default combineReducers({
   tweets,
   countries,
-  view
+  view,
+  filters
 });

--- a/src/reducers/view.js
+++ b/src/reducers/view.js
@@ -1,8 +1,14 @@
-import { TWEET_RECEIVED, TWEET_SELECTED } from '../actions';
+import {
+  TWEET_RECEIVED,
+  TWEET_SELECTED,
+  FILTER_ACTIVE_CHANGED,
+  FILTER_DELETED
+} from '../actions';
 
 const initialState = {
   tweetCount: 0,
-  currentTweet: null
+  currentTweet: null,
+  activeFilterIdsMap: {}
 };
 
 export default function (state = initialState, action) {
@@ -16,6 +22,22 @@ export default function (state = initialState, action) {
     return {
       ...state,
       currentTweet: action.tweet
+    };
+  case FILTER_ACTIVE_CHANGED:
+    return {
+      ...state,
+      activeFilterIdsMap: {
+        ...state.activeFilterIdsMap,
+        [action.filter.id]: action.active
+      }
+    };
+  case FILTER_DELETED:
+    return {
+      ...state,
+      activeFilterIdsMap: {
+        ...state.activeFilterIdsMap,
+        [action.filter.id]: false
+      }
     };
   default:
     return state;

--- a/src/util/filters.js
+++ b/src/util/filters.js
@@ -1,0 +1,32 @@
+function matchesHashtags(tweet) {
+  return filter =>
+    tweet.entities.hashtags &&
+    filter.hashtags &&
+      tweet.entities.hashtags
+        .map(h => h.text)
+        .some(h => filter.hashtags.find(fh => fh === h));
+}
+
+function matchesText(tweet) {
+  return filter =>
+    tweet.text &&
+    tweet.text.indexOf(filter.text) > -1;
+}
+
+function matchesGeo(tweet) {
+  return filter => false;
+}
+
+function filterMatch(tweet) {
+  const matchers = [
+    matchesHashtags,
+    matchesText,
+    matchesGeo
+  ].map(m => m(tweet));
+
+  return filter => matchers.some(m => m(filter));
+}
+
+export function findFilterMatch(tweet, filters) {
+  return filters.find(filterMatch(tweet));
+}


### PR DESCRIPTION
You can now filter tweets based on hashtag(s) and text. If a tweet is matched against a filter, the filter's color will be used for the map marker.

Supported colors for map markers (as per https://sites.google.com/site/gmapsdevelopment/):

```
* yellow
* blue
* green
* lightblue
* orange
* pink
* purple
* red
```